### PR TITLE
[fix] work with github like URLs for extracting repo/user

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function url(data, contains) {
  * @api public
  */
 function parse(data) {
-  var http = /github.com[\/|:]([^\/]+)\/([^\/|\s|\)]+)[.git|\/]?/i
+  var http = /github\.[^\/:]+[\/|:]([^\/]+)\/([^\/|\s|\)]+)[.git|\/]?/i
     , githubio = /https?:\/\/([^\.]+)\.github\.io\/([^\/|\s|\)]+)\/?/i
     , travisci = /travis-ci\.org\/(.*)\/(.*)\.png/i
     , type = parse.type(data)


### PR DESCRIPTION
Loosen the regex so we can match internal github endpoints
